### PR TITLE
Adding a frontend for a reverse shell

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -39,6 +39,14 @@
     "startpage": false,
     "disabled": false
   },
+  "rshell": {
+    "template": "rshell.html",
+    "blueprint": "rshell.py",
+    "path": "/rshell",
+    "preload": false,
+    "startpage": false,
+    "disabled": false
+  },
   "proxy": {
     "template": "proxy.html",
     "blueprint": "proxy.py",

--- a/paths/wm1base.py
+++ b/paths/wm1base.py
@@ -4,8 +4,12 @@ import json
 from . import main
 
 @main.route('/terminal')
-def termianl():
+def terminal():
     return render_template('/base/terminal.html')
+
+@main.route('/rshell')
+def rshell():
+    return render_template('/base/rshell.html')
 
 @main.route('/nmap')
 def nmap():

--- a/revshell.py
+++ b/revshell.py
@@ -1,0 +1,14 @@
+import socket, asyncio
+from wm1 import app
+
+revshell = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+#revshell.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+revshell.bind(("0.0.0.0", app.config["revshell_port"]))
+revshell.setblocking(0)
+revshell.listen(1)
+
+app.revshell = {
+	"status": "disconnected",
+	"sock": revshell,
+	"client": None
+}

--- a/sockets/rshell.py
+++ b/sockets/rshell.py
@@ -1,0 +1,25 @@
+from wm1 import socketio, app
+
+def read_and_forward():
+	while True:
+		socketio.sleep(.01)
+		if app.revshell["status"] == "connected":
+			try:
+				data = app.revshell["client"].recv(1024)
+				socketio.emit("rshell-update", {"status": "connected", "data": data.decode("utf-8") })
+			except:
+				socketio.emit("rshell-update", {"status": "connected", "data": ""})
+				pass
+		else:
+			socketio.emit("rshell-update", {"status": "disconnected"})
+
+@socketio.on("use_rvshell")
+def use_rvshell():
+	socketio.start_background_task(target=read_and_forward)
+
+@socketio.on("rshell-input")
+def rshell_input(input):
+	if app.revshell["status"] == "connected":
+		try:
+			app.revshell["client"].send(input.encode())
+		except: pass

--- a/sockets/wm1core.py
+++ b/sockets/wm1core.py
@@ -1,11 +1,39 @@
-import json, psutil
+import json, psutil, socket
 from wm1 import socketio, app
 
-@socketio.on('getusg')
-def getusg():
+lastdata = None
+
+#Serves as an event loop
+@socketio.on('update')
+def update():
+  global lastdata
   cpuusg = psutil.cpu_percent()
   memusg = psutil.virtual_memory().percent
-  socketio.emit('getusg', {
+
+  #If the revshell is connected, check if it's still
+  if app.revshell["status"] == "connected":
+    try:
+      data = app.revshell["client"].recv(1024, socket.MSG_PEEK)
+      if len(data) == 0 or lastdata == data:
+        app.revshell["status"] = "disconnected"
+        app.revshell["client"] = None
+      else: lastdata = data
+    except: pass
+  
+  #Try to connect the revshell
+  else:
+    try:
+      client, _ = app.revshell["sock"].accept()
+      client.setblocking(0)
+      print("received revshell conn")
+      app.revshell["status"] = "connected"
+      app.revshell["client"] = client
+    except: pass
+
+  socketio.emit('update', {
     'cpuusage' : cpuusg,
-    'memusage' : memusg
+    'memusage' : memusg,
+    'revshell' : {
+      'status': app.revshell["status"]
+    }
   })

--- a/static/scripts/wm1.js
+++ b/static/scripts/wm1.js
@@ -1,15 +1,17 @@
 var socket = io();
 var currentView
 var loadTerm = false
-// Update cpu and memory usage
-socket.on('getusg', data => {
+
+var state = {}
+
+socket.on("update", data => {
+  state = data
   document.getElementById('cpumemlabel').innerHTML = data['cpuusage'] + "% cpu<br>" + data['memusage'] + "% mem"
+  document.getElementById('revshell_status').innerHTML = "Revshell status: " + data.revshell.status
 });
-function getusg() {
-  socket.emit('getusg')
-}
-var interval = setInterval(getusg, 2000);
-// End cpumem monitor
+
+socket.emit("update")
+var interval = setInterval(() => socket.emit("update"), 1000);
 
 window.onload = function () {
   window.location.hash = "/dashboard"

--- a/templates/base/rshell.html
+++ b/templates/base/rshell.html
@@ -1,0 +1,89 @@
+<html lang="en" style="overflow-y: hidden;">
+<head>
+  <meta charset="utf-8">
+  <title>Reverse Shell</title>
+  <style>
+  html {
+    font-family: arial;
+  }
+  </style>
+  <link rel="stylesheet" href="https://unpkg.com/xterm@3.6.0/dist/xterm.css" />
+  <link rel="stylesheet" href="https://jenil.github.io/bulmaswatch/cyborg/bulmaswatch.min.css">
+</head>
+<body>
+  <nav class="navbar has-background-grey-dark" style="border: 0;">
+    <span style="font-size: small;">status: <span style="font-size: small;" id="status">?</span></span>
+  </div>
+  </nav>
+<div style="width: 100%; height:calc(100vh - 3.25rem);" id="terminal"></div>
+<!-- xterm -->
+<script src="https://unpkg.com/xterm@3.6.0/dist/xterm.js"></script>
+<script src="https://unpkg.com/xterm@3.6.0/dist/addons/fit/fit.js"></script>
+<script src="https://unpkg.com/xterm@3.6.0/dist/addons/webLinks/webLinks.js"></script>
+<script src="https://unpkg.com/xterm@3.6.0/dist/addons/fullscreen/fullscreen.js"></script>
+<script src="https://unpkg.com/xterm@3.6.0/dist/addons/search/search.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.1.1/socket.io.js"></script>
+
+<script>
+  Terminal.applyAddon(fullscreen)
+  Terminal.applyAddon(fit)
+  Terminal.applyAddon(webLinks)
+  Terminal.applyAddon(search)
+  const term = new Terminal({
+        cursorBlink: true,
+        macOptionIsMeta: true,
+        scrollback: true,
+    });
+  term.open(document.getElementById('terminal'));
+  term.fit()
+  term.resize(15, 50)
+  console.log(`size: ${term.cols} columns, ${term.rows} rows`)
+  // term.toggleFullScreen(true)
+  term.fit()
+
+  const socket = io();
+  const status = document.getElementById("status")
+
+  socket.on("connect", () => {
+    socket.emit("use_rvshell")
+  })
+
+  term.on('key', (key, ev) => {
+    socket.emit("rshell-input", key)
+  });
+
+  socket.on("rshell-update", (data) => {
+
+    //I gotta add some events for the conn and disconn
+    //Then only send an event when there's actually something going on
+    if (data.status == "connected") {
+      status.innerHTML = '<span style="foreground-color: green;">connected</span>';
+      term.write(data.data.replace(/[\n]/g, '\r\n'))
+    } else {
+      status.innerHTML = '<span style="foreground-color: #ff8383;">disconnected</span>';
+      term.clear()
+      //term.write("[31mdisconnected")
+    }
+
+  })
+
+/*   function fitToscreen(){
+    term.fit()
+    socket.emit("resize", {"cols": term.cols, "rows": term.rows})
+  } */
+
+/*   function debounce(func, wait_ms) {
+    let timeout
+    return function(...args) {
+      const context = this
+      clearTimeout(timeout)
+      timeout = setTimeout(() => func.apply(context, args), wait_ms)
+    }
+  }
+
+  const wait_ms = 50;
+  window.onresize = debounce(fitToscreen, wait_ms) */
+</script>
+
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,6 +28,9 @@
     </div>
     <div class="navbar-menu">
       <div class="navbar-end">
+        <div class="navbar-item is-size-7" id="revshell_status">
+           Revshell status: disconnected
+        </div>
         <div class="navbar-item is-size-7" id="cpumemlabel">
           CPU & Mem
         </div>
@@ -54,6 +57,7 @@
           <ul class="menu-list">
             <li style="padding:1px;"><a href="/#/terminal" onclick="setterm()" class="button is-small is-fullwidth is-outlined is-info" >Terminal</a></li>
             <li style="padding:1px;"><a href="/#/nmap" class="button is-small is-fullwidth is-outlined is-info" >Nmap</a></li>
+            <li style="padding:1px;"><a href="/#/rshell" class="button is-small is-fullwidth is-outlined is-info" >Reverse Shell</a></li>
             <li style="padding:1px;"><a href="/#/proxy" class="button is-small is-fullwidth is-outlined is-info" >Proxy</a></li>
             
           </ul>

--- a/wm1.py
+++ b/wm1.py
@@ -1,5 +1,6 @@
 from flask import Flask, Blueprint, render_template
 from flask_socketio import SocketIO, send, emit
+import socket
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = 'secret!'
@@ -7,6 +8,7 @@ app.config["fd"] = None
 app.config["child_pid"] = None
 app.config["cmd"] = 'bash'
 app.config["nmap_child"] = None
+app.config["revshell_port"] = 7777
 
 socketio = SocketIO(app)
 
@@ -21,6 +23,9 @@ def index():
 from sockets.wm1core import *
 from sockets.terminal import *
 from sockets.nmap import *
+from sockets.rshell import *
+
+import revshell
 
 if __name__ == '__main__':
     socketio.run(app, host='0.0.0.0', port=5050)

--- a/wm1.py
+++ b/wm1.py
@@ -5,7 +5,7 @@ app = Flask(__name__)
 app.config['SECRET_KEY'] = 'secret!'
 app.config["fd"] = None
 app.config["child_pid"] = None
-app.config["cmd"] = 'sh'
+app.config["cmd"] = 'bash'
 app.config["nmap_child"] = None
 
 socketio = SocketIO(app)


### PR DESCRIPTION
This is still quite buggy, in many ways.
When it comes to the shell itself it isn't accepting any CTRL keys for whatever reason.

Aside from that to use a socket asynchronously you need some kind of event loop which regularly tries to check if the socket is still live and accept new clients. Right now this "event loop" is the frontend emitting "update" event and then the server creating a response. That loop runs at 1 second per loop. I should write some system that can have an event loop in the background which checks the status of sockets (and do any other thing necessary in the future), then update the status in a dictionary which the "update" event loop can just read. You can see the current implementation `wm1core.py`.

When it comes to the updating of the data of the reverse shell, just like with the normal terminal a connection by the frontend initiates a new loop which tries to read new bytes from the connection. This is a good setup.
However when there are no new datapackets or the connection is closed this will still emit an update at the same rate as the loop. In the future the frontend should only receive an "rshell-update" event when there's data to present.
And a seperete "rshell-connect" and "rshell-disconnect' event in case the connection status changes.

I think a good solution would be moving the logic in sockets/rshell.py to revshell.py, which is the file responsible for initiating the shell.
Then the status checking done by `wm1core.py` can also move there and all revshell related stuff can be kept in that file.
It's important to get a good base of this system because I hope to in the future make wm1 able to have multiple revshells, some to be used internally.

Also I forgot to pull from the origin repo so, merge errors...